### PR TITLE
Add shard info to server info command

### DIFF
--- a/src/main/java/com/bot/commands/general/ServerInfoCommand.java
+++ b/src/main/java/com/bot/commands/general/ServerInfoCommand.java
@@ -41,6 +41,7 @@ public class ServerInfoCommand extends GeneralCommand {
         embedBuilder.addField("Roles", g.getRoles().size() + "", false);
         embedBuilder.addField("Custom Emojis", customEmojis, false);
         embedBuilder.addField("Region", g.getRegionRaw(), false);
+        embedBuilder.addField("Shard", commandEvent.getJDA().getShardInfo().getShardString(), false);
         embedBuilder.setFooter(FormattingUtils.formatOffsetDateTimeToDay(g.getTimeCreated()), null);
         commandEvent.reply(embedBuilder.build());
     }


### PR DESCRIPTION
[//]: # (Please try to use this template, feel free to remove sections or add more you may think are relevant.)

## Old Commands affected
- Adds shard info to ~sinfo command.
![image](https://user-images.githubusercontent.com/12740851/66708605-96696b80-ed18-11e9-8d8f-2be1f2bd6995.png)

### Questions
#### Does this use the database?
No
#### Does this store user data?
No...
#### Does this talk to a 3rd party API or Service?
No

## Reviewers
- [ ] @JessWalters
